### PR TITLE
add lock around tail.reader to prevent race

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -380,12 +380,14 @@ func (tail *Tail) waitForChanges() error {
 }
 
 func (tail *Tail) openReader() {
+	tail.lk.Lock()
 	if tail.MaxLineSize > 0 {
 		// add 2 to account for newline characters
 		tail.reader = bufio.NewReaderSize(tail.file, tail.MaxLineSize+2)
 	} else {
 		tail.reader = bufio.NewReader(tail.file)
 	}
+	tail.lk.Unlock()
 }
 
 func (tail *Tail) seekEnd() error {


### PR DESCRIPTION
Prevents a race condition on `tail.reader`. All the reads on this variable are protected by a lock, but the write isn't.

Ref https://github.com/hpcloud/tail/pull/114