### PR TITLE
prevent race condition decrementing watch count to negative

### DIFF
--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -175,10 +175,14 @@ func (shared *InotifyTracker) removeWatch(winfo *watchInfo) error {
 		// Watch for new files to be created in the parent directory.
 		fname = filepath.Dir(fname)
 	}
-	shared.watchNums[fname]--
-	watchNum := shared.watchNums[fname]
-	if watchNum == 0 {
-		delete(shared.watchNums, fname)
+	// guard against decrementing past 0
+	watchNum := -1
+	if _, ok := shared.watchNums[fname]; ok {
+		shared.watchNums[fname]--
+		watchNum = shared.watchNums[fname]
+		if watchNum == 0 {
+			delete(shared.watchNums, fname)
+		}
 	}
 	shared.mux.Unlock()
 


### PR DESCRIPTION
Prevents negative watch counts when removeWatch is called when there is no such watch. A negative watch count prevents future watches from being created for that path.

Should resolve https://github.com/influxdata/telegraf/issues/3573