### PR TITLE
chore: fix race condition in watcher implementations

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -7,11 +7,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/influxdata/tail/util"
+	"sync/atomic"
 
 	"gopkg.in/fsnotify.v1"
 	"gopkg.in/tomb.v1"
+
+	"github.com/influxdata/tail/util"
 )
 
 // InotifyFileWatcher uses inotify to monitor file changes.
@@ -72,14 +73,14 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 	}
 
 	changes := NewFileChanges()
-	fw.Size = pos
+	atomic.StoreInt64(&fw.Size, pos)
 
 	go func() {
 
 		events := Events(fw.Filename)
 
 		for {
-			prevSize := fw.Size
+			prevSize := atomic.LoadInt64(&fw.Size)
 
 			var evt fsnotify.Event
 			var ok bool
@@ -125,14 +126,13 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 					// XXX: report this error back to the user
 					util.Fatal("Failed to stat file %v: %v", fw.Filename, err)
 				}
-				fw.Size = fi.Size()
+				atomic.StoreInt64(&fw.Size, fi.Size())
 
-				if prevSize > 0 && prevSize > fw.Size {
+				if prevSize > 0 && prevSize > atomic.LoadInt64(&fw.Size) {
 					changes.NotifyTruncated()
 				} else {
 					changes.NotifyModified()
 				}
-				prevSize = fw.Size
 			}
 		}
 	}()

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -3,7 +3,6 @@ package watch
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/tomb.v1"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"gopkg.in/tomb.v1"
 )
 
 func TestWatchNotify(t *testing.T) {
@@ -44,8 +45,8 @@ func TestWatchNotify(t *testing.T) {
 			var werr error
 			changes := 0
 			chanClose := make(chan struct{})
+			wg.Add(1)
 			go func() {
-				wg.Add(1)
 				changes, werr = watchFile(filePath, test.poll, chanClose)
 				wg.Done()
 			}()


### PR DESCRIPTION
There seems to be a race condition in `fw.size` when I ran the test. 
I have used atomic.XXInt64 operations to ensure atomic read and writes.

```console
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestWatchNotify$ github.com/influxdata/tail/watch -race -v logtostderr

=== RUN   TestWatchNotify
=== RUN   TestWatchNotify/Test_watch_inotify
Modified
==================
WARNING: DATA RACE
Write at 0x00c000012028 by goroutine 9:
  github.com/influxdata/tail/watch.(*InotifyFileWatcher).ChangeEvents()
      /Users/neelay.upadhyaya/workspace/tail/watch/inotify.go:75 +0x22a
  github.com/influxdata/tail/watch.watchFile()
      /Users/neelay.upadhyaya/workspace/tail/watch/watch_test.go:136 +0x214
  github.com/influxdata/tail/watch.TestWatchNotify.func1.1()
      /Users/neelay.upadhyaya/workspace/tail/watch/watch_test.go:49 +0xa4

Previous read at 0x00c000012028 by goroutine 12:
  github.com/influxdata/tail/watch.(*InotifyFileWatcher).ChangeEvents.func1()
      /Users/neelay.upadhyaya/workspace/tail/watch/inotify.go:135 +0x529
```

Logs are truncated, but they are also present in other places.