### PR TITLE
feat: support for 'create' event from the inotify watcher

### DIFF
--- a/watch/filechanges.go
+++ b/watch/filechanges.go
@@ -4,11 +4,16 @@ type FileChanges struct {
 	Modified  chan bool // Channel to get notified of modifications
 	Truncated chan bool // Channel to get notified of truncations
 	Deleted   chan bool // Channel to get notified of deletions/renames
+	Created   chan bool // Channel to get notified of creations
 }
 
 func NewFileChanges() *FileChanges {
 	return &FileChanges{
-		make(chan bool, 1), make(chan bool, 1), make(chan bool, 1)}
+		make(chan bool, 1),
+		make(chan bool, 1),
+		make(chan bool, 1),
+		make(chan bool, 1),
+	}
 }
 
 func (fc *FileChanges) NotifyModified() {
@@ -21,6 +26,10 @@ func (fc *FileChanges) NotifyTruncated() {
 
 func (fc *FileChanges) NotifyDeleted() {
 	sendOnlyIfEmpty(fc.Deleted)
+}
+
+func (fc *FileChanges) NotifyCreated() {
+	sendOnlyIfEmpty(fc.Created)
 }
 
 // sendOnlyIfEmpty sends on a bool channel only if the channel has no

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -133,6 +133,8 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 				} else {
 					changes.NotifyModified()
 				}
+			case evt.Op&fsnotify.Create == fsnotify.Create:
+				changes.NotifyCreated()
 			}
 		}
 	}()

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -11,10 +11,11 @@ type FileWatcher interface {
 	BlockUntilExists(*tomb.Tomb) error
 
 	// ChangeEvents reports on changes to a file, be it modification,
-	// deletion, renames or truncations. Returned FileChanges group of
+	// deletion, creation, renames or truncations. Returned FileChanges group of
 	// channels will be closed, thus become unusable, after a deletion
 	// or truncation event.
 	// In order to properly report truncations, ChangeEvents requires
 	// the caller to pass their current offset in the file.
+	// File creations are reported when the watcher is initialized on the parent directory.
 	ChangeEvents(*tomb.Tomb, int64) (*FileChanges, error)
 }


### PR DESCRIPTION
Inotify watcher type will now emit "CREATE" file event when the watcher is defined on the parent directory.

PS: It also shows commit from the Previous unmerged PR