### PR TITLE
feat: Allow customizable polling duration per watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .test
 .go
+.idea/*
 


### PR DESCRIPTION
Adds a customizable poll duration per watcher for polling file watchers. I did this by creating another function, and leaving the old `POLL_DURATION` field behind since I didn't want to break anyone using this library elsewhere.

I also added `.idea/` to the gitignore since I use Goland and these files shouldn't be committed.

